### PR TITLE
add manifest_version

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -17,5 +17,6 @@
     "ArchiHome": [
       "i18n"
     ]
-  }
+  },
+  "manifest_version": 2
 }


### PR DESCRIPTION
Fixes:

    php /var/www/public/wiki/w/extensions/FlaggedRevs/maintenance/updateStats.php

> PHP Deprecated:  Link to Archive's extension.json or skin.json does not have manifest_version, this is deprecated since MediaWiki 1.29 in /var/www/public/wiki/w/includes/debug/MWDebug.php on line 376

Which happens for all mediawiki maintenance php scripts and even shows in the wiki after update.